### PR TITLE
Bugfix related to Mac/Win-Incompatibility

### DIFF
--- a/branches/busmezzo/mezzo_lib/src/busline.cpp
+++ b/branches/busmezzo/mezzo_lib/src/busline.cpp
@@ -1073,7 +1073,7 @@ void Busstop::book_bus_arrival(Eventlist* eventlist, double time, Bustrip* trip)
 }
 
 
-void Busstop::add_walking_time_quantiles(Busstop* dest_stop_ptr, double* quantiles, double* quantile_values, int num_quantiles, double interval_start, double interval_end){
+void Busstop::add_walking_time_quantiles(Busstop* dest_stop_ptr, vector<double> quantiles, vector<double> quantile_values, int num_quantiles, double interval_start, double interval_end){
     
     Walking_time_dist* time_dist = new Walking_time_dist(dest_stop_ptr, quantiles, quantile_values, num_quantiles, interval_start, interval_end);
     
@@ -2385,7 +2385,7 @@ bool Change_arrival_rate::execute(Eventlist* eventlist, double time) //variables
 	return true;
 }
 
-Walking_time_dist::Walking_time_dist(Busstop* dest_stop_, double* quantiles_, double* quantile_values_, int num_quantiles_, double time_start_, double time_end_){
+Walking_time_dist::Walking_time_dist(Busstop* dest_stop_, vector<double> quantiles_, vector<double> quantile_values_, int num_quantiles_, double time_start_, double time_end_){
     
     dest_stop = dest_stop_;
     num_quantiles = num_quantiles_;

--- a/branches/busmezzo/mezzo_lib/src/busline.h
+++ b/branches/busmezzo/mezzo_lib/src/busline.h
@@ -685,7 +685,7 @@ public:
     //id(id_), name(name_), link_id(link_id_), position (position_), length(length_), has_bay(has_bay_), can_overtake(can_overtake_), min_DT(min_DT_), rti (rti_)
     
     //methods related to exogenous walking times
-    void add_walking_time_quantiles(Busstop*, double*, double*, int, double, double);
+    void add_walking_time_quantiles(Busstop*, vector<double>, vector<double>, int, double, double);
     double estimate_walking_time_from_quantiles(Busstop*, double);
 
 
@@ -748,7 +748,7 @@ protected:
 	map<Busstop*,double> distances;			//!< contains the distances [meters] from other bus stops
     
     // walking times between steps
-    map<Busstop*, vector<Walking_time_dist*>> walking_time_distribution_map; //!< contains set of distributions for a given destination node
+    map<Busstop*, vector<Walking_time_dist*> > walking_time_distribution_map; //!< contains set of distributions for a given destination node
 
 
 	// transfer synchronization
@@ -782,7 +782,7 @@ protected:
 
 class Walking_time_dist {
 public:
-    Walking_time_dist (Busstop* dest_stop_, double* quantiles_, double* quantile_values_, int num_quantiles_, double time_start_, double time_end_);
+    Walking_time_dist (Busstop* dest_stop_, vector<double> quantiles_, vector<double> quantile_values_, int num_quantiles_, double time_start_, double time_end_);
     
     virtual ~Walking_time_dist(){};
     

--- a/branches/busmezzo/mezzo_lib/src/network.cpp
+++ b/branches/busmezzo/mezzo_lib/src/network.cpp
@@ -5686,8 +5686,8 @@ bool Network::readwalkingtimedistribution(istream& in) // reads a walking time d
     dest_stop_ptr = get_busstop_from_name(dest_name);
     
     //containers for quantile position and quantile values
-    double quantiles[num_quantiles];
-    double quantile_values[num_quantiles];
+    vector<double> quantiles(num_quantiles);
+    vector<double> quantile_values(num_quantiles);
     
     //get quantile positions
     in >> bracket;


### PR DESCRIPTION
Tested also by David on Windows. Compiles fine and runs with SF network. Network specification and I/O description on DropBox are also up-to-date.

(Converted double array into vector<double> to allow for variable array length also without compiler extension for compatibility with Visual Studio.)